### PR TITLE
Rows makeover

### DIFF
--- a/bin/greptokens
+++ b/bin/greptokens
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+"""
+   Parse regular expressions out of stdin and print only those tokens
+"""
+
+import re
+import sys
+
+def syntax(msg=None):
+  if msg:
+    sys.stderr.write('{msg}\n'.format(**locals()))
+  sys.stderr.write('Syntax: {pgm} REGEXP\n'.format(pgm=sys.argv[0]))
+  exit(1)
+
+if sys.stdin.isatty():
+  syntax('stdin must be redirected')
+
+if len(sys.argv) != 2:
+  syntax()
+
+regexp = re.compile(sys.argv[1])
+for line in sys.stdin.read().splitlines():
+  print [hit.group(0) for hit in regexp.finditer(line)]

--- a/bin/rows
+++ b/bin/rows
@@ -42,11 +42,26 @@ re_regexp = re.compile('^re=(.+)$')
 
 lines = sys.stdin.read().splitlines()
 
+def parse(arg, lines):
+  pos = int(arg)
+  if pos < 0:
+    pos = lines + pos
+  if pos >= lines:
+    syntax('{arg!r} is an invalid position, there are only {lines} lines'.format(**locals()))
+  return pos
+
 choices = [negate] * len(lines)
 for arg in args:
   match = range_regexp.search(arg)
   if match:
-    pass
+    start = parse(match.group(1), len(lines))
+    if match.group(2):
+      stop = parse(match.group(3), len(lines))
+    else:
+      stop = start
+
+    for pos in range(start, stop+1):
+      choices[pos] = not negate
   else:
     match = re_regexp.search(arg)
     if match:
@@ -54,10 +69,8 @@ for arg in args:
       for (pos, line) in enumerate(lines):
         match = regexp.search(line)
         # print regexp.pattern, line, match
-        if match and (not choices[pos]):
-          choices[pos] = True
-        elif (not match) and choices[pos]:
-          choices[pos] = False
+        if match:
+          choices[pos] = not negate
     else:
       syntax('{arg!r} is not recognized')
 

--- a/bin/rows
+++ b/bin/rows
@@ -1,60 +1,66 @@
 #! /usr/bin/env python
 
 """
-  Display portions of stdin through their specific line numbers (positive integers, base 0).
+  Display portions of stdin through their specific line numbers (zero based), ranges of line numbers, and regular expressions
 
-  Examples:
-    
-    cat ... | rows 0 10 20 30 0 # first line is repeated
-    rows {0..99} < file         # works the same as `head -100`, relies on the shell to expand the range before the script is even invoked
+    rows 1:-2 # print lines 2 up through and including the next to last line
+    row -v re=foo  # print all lines except those that match the regular expression `foo`
 """
 
 import sys
 import re
 import getopt
 
-assert not sys.stdin.isatty(), 'stdin must be redirected'
+def syntax(msg=None):
+  if msg:
+    sys.stderr.write('{msg}\n'.format(**locals()))
+  sys.stderr.write('Syntax: {pgm} [-v|--negate] [NUM[:NUM]] [re=REGEXP] ... \n'.format(pgm=sys.argv[0]))
+  exit(1)
 
-assert len(sys.argv) > 1, 'Syntax: {pgm} NUM|(NUM)-(NUM)|(NUM):(NUM)|re=REGEXP ...'.format(pgm=sys.argv[0])
+if sys.stdin.isatty():
+  syntax('stdin must be redirected')
 
-numeric_regexp = re.compile('^(\d+)?([-:])(\d+)?$')
+negate = False
+
+(opts, args) = ([], [])
+try:
+  (opts, args) = getopt.getopt(sys.argv[1:], 'v', ['negate'])
+except Exception as e:
+  syntax('Caught `{e!s}`'.format(**locals()))
+
+for (opt, arg) in opts:
+  if opt in ['-v', '--negate']:
+    negate = not negate
+  else:
+    syntax('Unexpected option {opt!r}'.format(**locals()))
+
+if not args:
+  syntax('No ranges or regular expressions specified')
+
+range_regexp = re.compile('^(-?\d+)(:(-?\d+))?$')
 re_regexp = re.compile('^re=(.+)$')
 
 lines = sys.stdin.read().splitlines()
 
-for arg in sys.argv[1:]:
-  match = numeric_regexp.search(arg)
+choices = [negate] * len(lines)
+for arg in args:
+  match = range_regexp.search(arg)
   if match:
-    if match.group(1) is not None:
-      start = int(match.group(1))
-    else:
-      start = 0
-
-    if match.group(2) == '-':
-      if match.group(3) is not None:
-        stop = int(match.group(3))
-      else:
-        stop = len(lines)-1
-      assert stop >= start, '{start} > {stop}'.format(**locals())
-    else:
-      if match.group(3) is not None:
-        stop = start + int(match.group(3)) - 1
-      else:
-        stop = len(lines)-1
-
-    assert (start >= 0) and (stop < len(lines)), '{arg!r} is out of range - stdin has {lines} lines'.format(arg=arg, lines=len(lines))
-
-    for num in range(start, stop+1):
-      print lines[num]
-
+    pass
   else:
     match = re_regexp.search(arg)
     if match:
       regexp = re.compile(match.group(1))
-      for line in lines:
-        if regexp.search(line):
-          print line
+      for (pos, line) in enumerate(lines):
+        match = regexp.search(line)
+        # print regexp.pattern, line, match
+        if match and (not choices[pos]):
+          choices[pos] = True
+        elif (not match) and choices[pos]:
+          choices[pos] = False
     else:
-      arg = int(arg)
-      assert 0 <= arg < len(lines), '`{arg}` is out of range - stdin has {lines} lines'.format(arg=arg, lines=len(lines))
-      print lines[arg]
+      syntax('{arg!r} is not recognized')
+
+for (pos, chosen) in enumerate(choices):
+  if chosen:
+    print lines[pos]

--- a/bin/rows
+++ b/bin/rows
@@ -11,10 +11,18 @@ import sys
 import re
 import getopt
 
+def debug(msg):
+  if verbose:
+    sys.stderr.write('{msg}\n'.format(**locals()))
+
+def see(expr):
+  value = eval(expr)
+  debug('{expr}: {value}'.format(**locals()))
+
 def syntax(msg=None):
   if msg:
     sys.stderr.write('{msg}\n'.format(**locals()))
-  sys.stderr.write('Syntax: {pgm} [-v|--negate] [-i|--immediate] [NUM[:NUM]] [re=REGEXP] ... \n'.format(pgm=sys.argv[0]))
+  sys.stderr.write('Syntax: {pgm} [-v|--negate] [-i|--immediate] [-d|--debug] [NUM[:NUM]] [re=REGEXP] ... \n'.format(pgm=sys.argv[0]))
   exit(1)
 
 if sys.stdin.isatty():
@@ -22,10 +30,11 @@ if sys.stdin.isatty():
 
 negate = False
 immediate = False
+verbose = False
 
 (opts, args) = ([], [])
 try:
-  (opts, args) = getopt.getopt(sys.argv[1:], 'vi', ['negate', 'immediate'])
+  (opts, args) = getopt.getopt(sys.argv[1:], 'vid', ['negate', 'immediate', 'debug'])
 except Exception as e:
   syntax('Caught `{e!s}`'.format(**locals()))
 
@@ -34,6 +43,8 @@ for (opt, arg) in opts:
     negate = not negate
   elif opt in ['-i', '--immediate']:
     immediate = not immediate
+  elif opt in ['-d', '--debug']:
+    verbose = not verbose
   else:
     syntax('Unexpected option {opt!r}'.format(**locals()))
 
@@ -69,7 +80,8 @@ for arg in args:
 
     if immediate:
       for pos in range(count):
-        if (start <= pos < stop) != negate:
+        see('pos, lines[pos], start <= pos <= stop, negate')
+        if (start <= pos <= stop) != negate:
           print lines[pos]
     else:
       for pos in range(start, stop+1):
@@ -82,6 +94,7 @@ for arg in args:
         match = regexp.search(line)
         # print regexp.pattern, line, match
         if immediate:
+          see('pos, line, match, negate')
           if bool(match) != negate:
             print lines[pos]
         else:

--- a/bin/rows
+++ b/bin/rows
@@ -14,23 +14,26 @@ import getopt
 def syntax(msg=None):
   if msg:
     sys.stderr.write('{msg}\n'.format(**locals()))
-  sys.stderr.write('Syntax: {pgm} [-v|--negate] [NUM[:NUM]] [re=REGEXP] ... \n'.format(pgm=sys.argv[0]))
+  sys.stderr.write('Syntax: {pgm} [-v|--negate] [-i|--immediate] [NUM[:NUM]] [re=REGEXP] ... \n'.format(pgm=sys.argv[0]))
   exit(1)
 
 if sys.stdin.isatty():
   syntax('stdin must be redirected')
 
 negate = False
+immediate = False
 
 (opts, args) = ([], [])
 try:
-  (opts, args) = getopt.getopt(sys.argv[1:], 'v', ['negate'])
+  (opts, args) = getopt.getopt(sys.argv[1:], 'vi', ['negate', 'immediate'])
 except Exception as e:
   syntax('Caught `{e!s}`'.format(**locals()))
 
 for (opt, arg) in opts:
   if opt in ['-v', '--negate']:
     negate = not negate
+  elif opt in ['-i', '--immediate']:
+    immediate = not immediate
   else:
     syntax('Unexpected option {opt!r}'.format(**locals()))
 
@@ -41,27 +44,36 @@ range_regexp = re.compile('^(-?\d+)(:(-?\d+))?$')
 re_regexp = re.compile('^re=(.+)$')
 
 lines = sys.stdin.read().splitlines()
+count = len(lines)
 
-def parse(arg, lines):
+def parse(arg):
   pos = int(arg)
   if pos < 0:
-    pos = lines + pos
-  if pos >= lines:
-    syntax('{arg!r} is an invalid position, there are only {lines} lines'.format(**locals()))
+    pos = count + pos
+  if (pos < 0) or (pos >= count):
+    syntax('{arg!r} is an invalid position, there are only {count} lines'.format(count=count, **locals()))
   return pos
 
-choices = [negate] * len(lines)
+choices = [negate] * count
 for arg in args:
   match = range_regexp.search(arg)
   if match:
-    start = parse(match.group(1), len(lines))
+    start = parse(match.group(1))
     if match.group(2):
-      stop = parse(match.group(3), len(lines))
+      stop = parse(match.group(3))
     else:
       stop = start
 
-    for pos in range(start, stop+1):
-      choices[pos] = not negate
+    if stop < start:
+      syntax('{arg!r} doesn\'t make sense with {count} lines'.format(**locals()))
+
+    if immediate:
+      for pos in range(count):
+        if (start <= pos < stop) != negate:
+          print lines[pos]
+    else:
+      for pos in range(start, stop+1):
+        choices[pos] = not negate
   else:
     match = re_regexp.search(arg)
     if match:
@@ -69,11 +81,16 @@ for arg in args:
       for (pos, line) in enumerate(lines):
         match = regexp.search(line)
         # print regexp.pattern, line, match
-        if match:
-          choices[pos] = not negate
+        if immediate:
+          if bool(match) != negate:
+            print lines[pos]
+        else:
+          if match:
+            choices[pos] = not negate
     else:
       syntax('{arg!r} is not recognized')
 
-for (pos, chosen) in enumerate(choices):
-  if chosen:
-    print lines[pos]
+if not immediate:
+  for (pos, chosen) in enumerate(choices):
+    if chosen:
+      print lines[pos]


### PR DESCRIPTION
This is a major rework of `rows` to accomplish a couple of things on my wishlist (#26 #23):

- Negative numbers can be used to express lines from the end of the file - -1 is the last line
- I added a `--negate` option
- I allowed for lines to be selected/deselected via a regular expression rather than the position of the line
- I added an `--immediate` option to print out lines *immediately* (instead of waiting for the second pass which only prints out each selected line once) resulting in duplicate lines if desired - for instance:
  ```
  $ peval '"\n".join([str(num) for num in range(5)])' | rows 0 0 0
  0
  $ peval '"\n".join([str(num) for num in range(5)])' | rows --immediate 0 0 0
  0
  0
  0
  $ 
  ```

Unlike Python indexing, the ending position is inclusive.  For example, `0:9` selects or deselects lines 0 through 9 inclusive.