### PR TITLE
Add a --yaml option to json script

### DIFF
--- a/bin/json
+++ b/bin/json
@@ -8,7 +8,7 @@ import itertools
 def syntax(msg):
     if msg:
         sys.stderr.write(msg + "\n")
-    sys.stderr.write("Syntax: %s [--verbose] [--flatten] [--describe] [--file FILENAME] [--depth DEPTH] [--forgive] [--linear] [--string] [path ...]\n" % sys.argv[0])
+    sys.stderr.write("Syntax: %s [--yaml] [--verbose] [--flatten] [--describe] [--file FILENAME] [--depth DEPTH] [--forgive] [--linear] [--string] [path ...]\n" % sys.argv[0])
     exit(1)
 
 def shorten(s, maxLen=80):
@@ -116,10 +116,11 @@ writer = jsonWriter
 filename = None
 depth = None
 forgive = False
+inputIsYaml = False
 
 (opts, args) = ([], [])
 try:
-    (opts,args) = getopt.getopt(sys.argv[1:], "v", ["verbose", "flat", "flatten", "describe", "file=", "depth=", "forgive", 'linear', 'string'])
+    (opts,args) = getopt.getopt(sys.argv[1:], "v", ["verbose", "flat", "flatten", "describe", "file=", "depth=", "forgive", 'linear', 'string', 'yaml'])
 except Exception as e:
     syntax(str(e))
 
@@ -143,6 +144,9 @@ for (opt,arg) in opts:
             syntax("Could not parse `%s %s`: %s" % (opt, arg, e))
     elif opt == "--forgive":
        forgive = not forgive
+    elif opt == "--yaml":
+       inputIsYaml = not inputIsYaml
+       import yaml
     else:
         syntax("Don't know how to handle %s" % repr(opt))
 
@@ -158,7 +162,10 @@ else:
 
 root = None
 try:
-    root = json.loads(data)
+    if inputIsYaml:
+      root = yaml.load(data)
+    else:
+      root = json.loads(data)
 except Exception as e:
     syntax("Could not parse %s: %s" % (repr(shorten(data)), str(e)))
 


### PR DESCRIPTION
I had a need to read a YAML file and display it as JSON.

I did this to a separate branch because I wasn't sure what would happen with the `import yaml` if the pyyaml package isn't installed.  I do the `import` inside an `if` statement but I wasn't sure that it wouldn't throw an error if the `if` condition wasn't true.

I tried the script on a system that didn't have pyyaml installed.  It ran fine and worked as JSON when the `--yaml` option wasn't used and it crapped out when the option was specified.