### PR TITLE
Changing scripts to explicitly use python2 rather than python

### DIFF
--- a/bin/BrunoUtils.py
+++ b/bin/BrunoUtils.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 import platform
 import subprocess
 import os

--- a/bin/Data.py
+++ b/bin/Data.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import random

--- a/bin/Decolorizer.py
+++ b/bin/Decolorizer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 class Decolorizer:
   escape = '\033'

--- a/bin/SecureKeyValues.py
+++ b/bin/SecureKeyValues.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/abspath
+++ b/bin/abspath
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 description='Return absolute paths of files, especially Cygwin domain to Windoze domain when appropriate'
 

--- a/bin/acp
+++ b/bin/acp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/addcrs
+++ b/bin/addcrs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Add carriage returns to a text file

--- a/bin/aliasgrep
+++ b/bin/aliasgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/allcommits
+++ b/bin/allcommits
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/anonymize
+++ b/bin/anonymize
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/ansible2json
+++ b/bin/ansible2json
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Turn Ansible output into full JSON.  It's pretty close to JSON but

--- a/bin/ansiblehelper.py
+++ b/bin/ansiblehelper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/ansibleping
+++ b/bin/ansibleping
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging
 import argparse

--- a/bin/ansiblescp
+++ b/bin/ansiblescp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/ansiblessh
+++ b/bin/ansiblessh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/append
+++ b/bin/append
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/assassinate
+++ b/bin/assassinate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
 A kind of quick-and-dirty script to kill all of my processes on a system *except* for those connected with the script and its ancestors:

--- a/bin/autoscp
+++ b/bin/autoscp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import time

--- a/bin/awshost
+++ b/bin/awshost
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/backup
+++ b/bin/backup
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/badimport
+++ b/bin/badimport
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/banner
+++ b/bin/banner
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/bashprofiles
+++ b/bin/bashprofiles
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/basicfy
+++ b/bin/basicfy
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/beeper
+++ b/bin/beeper
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import time

--- a/bin/bingrep
+++ b/bin/bingrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/boxes.py
+++ b/bin/boxes.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/br
+++ b/bin/br
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/bytes
+++ b/bin/bytes
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/capture
+++ b/bin/capture
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import time

--- a/bin/capture.py
+++ b/bin/capture.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Runs a shell command, capturing stdout and stderr to a file; reporting on start time, stop time, and duration; reporting on exit status; reporting on CPU time

--- a/bin/chainssh
+++ b/bin/chainssh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    ssh to one or more systems in a chain of one or more remote systems

--- a/bin/cleanup-commit-branches
+++ b/bin/cleanup-commit-branches
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/clone
+++ b/bin/clone
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   This is a quick and dirty script to `clone` (copy byte-by-byte) files from anywhere to the current working directory.

--- a/bin/color.py
+++ b/bin/color.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/cols
+++ b/bin/cols
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Print lines to identify the columns, keyed off the width of the screen.  Useful to know how long lines are, what column a character/field is in, etc.

--- a/bin/columns
+++ b/bin/columns
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import string

--- a/bin/comm2
+++ b/bin/comm2
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   A better `comm` that doesn't expect the files to be sorted.

--- a/bin/compressdiff
+++ b/bin/compressdiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import gzip

--- a/bin/connect
+++ b/bin/connect
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import socket

--- a/bin/copies
+++ b/bin/copies
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/cores
+++ b/bin/cores
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/crcheck
+++ b/bin/crcheck
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Check for those ugly Windoze-style carriage returns in

--- a/bin/datascope
+++ b/bin/datascope
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/datejuggle
+++ b/bin/datejuggle
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/datemath
+++ b/bin/datemath
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/daterep
+++ b/bin/daterep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Replace a timestamp expressed as seconds second the epoch with a more meaningful string of 

--- a/bin/datescope
+++ b/bin/datescope
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/decolor
+++ b/bin/decolor
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/delete_docker_containers
+++ b/bin/delete_docker_containers
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/delete_docker_images
+++ b/bin/delete_docker_images
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/diffall
+++ b/bin/diffall
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/dirdiff
+++ b/bin/dirdiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Compare the current working directory on the local machine with the contents of a directory on a remote machine.

--- a/bin/dirsum
+++ b/bin/dirsum
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/docker-proc
+++ b/bin/docker-proc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/dowhile
+++ b/bin/dowhile
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import subprocess

--- a/bin/drop
+++ b/bin/drop
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/dummycmd
+++ b/bin/dummycmd
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Print specified lines to stdout/stderr and exit with specified status

--- a/bin/elastic_elements
+++ b/bin/elastic_elements
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/elements
+++ b/bin/elements
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   assuming stdin is a json list of dictionaries, this script prints selected elements of a json list in a table

--- a/bin/elk
+++ b/bin/elk
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import docker
 import time

--- a/bin/epochrep
+++ b/bin/epochrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/equiv
+++ b/bin/equiv
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/exactscp
+++ b/bin/exactscp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Do scp's respecting the source path of regular files.  For instance:

--- a/bin/explode
+++ b/bin/explode
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Ideally, this will be a script that can take one or more tar or jar files and unwind them.

--- a/bin/extensions
+++ b/bin/extensions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import string

--- a/bin/feedElasticsearch
+++ b/bin/feedElasticsearch
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import getopt

--- a/bin/fernet
+++ b/bin/fernet
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/fifo
+++ b/bin/fifo
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/filecount
+++ b/bin/filecount
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Print the number of files in directories and their subdirectories

--- a/bin/fileinfo
+++ b/bin/fileinfo
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/findgrep
+++ b/bin/findgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Does `find DIR ... \( -type f [ ... ] \) -print0 | xargs -0 grep [OPT ...] REGEXP`

--- a/bin/findmetrics
+++ b/bin/findmetrics
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import datetime

--- a/bin/fitwidth
+++ b/bin/fitwidth
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import string

--- a/bin/fixknownhosts
+++ b/bin/fixknownhosts
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/flow
+++ b/bin/flow
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 import sys
 import os
 import getopt

--- a/bin/fmetrics
+++ b/bin/fmetrics
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/fullls
+++ b/bin/fullls
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import pwd

--- a/bin/fulltime
+++ b/bin/fulltime
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import string

--- a/bin/get
+++ b/bin/get
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/getCloudant
+++ b/bin/getCloudant
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Download one or more Cloudant documents.

--- a/bin/getmetrics
+++ b/bin/getmetrics
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import datetime

--- a/bin/git-extract
+++ b/bin/git-extract
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Extract all git commits of a file

--- a/bin/gitbranches
+++ b/bin/gitbranches
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Print git branches

--- a/bin/gitdiff
+++ b/bin/gitdiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Do `git diff` and process the output

--- a/bin/gitfiles
+++ b/bin/gitfiles
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/gitlog
+++ b/bin/gitlog
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/gitloggrep
+++ b/bin/gitloggrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/gitpush
+++ b/bin/gitpush
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   This solves the problem of pushing commits to a git server when the 

--- a/bin/gitrepos
+++ b/bin/gitrepos
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Find and display git repos

--- a/bin/gitstatus
+++ b/bin/gitstatus
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/gitstatus.py
+++ b/bin/gitstatus.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/gitter
+++ b/bin/gitter
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/grafana
+++ b/bin/grafana
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import docker

--- a/bin/grepall
+++ b/bin/grepall
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/grepgrep
+++ b/bin/grepgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/greptokens
+++ b/bin/greptokens
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Parse regular expressions out of stdin and print only those tokens

--- a/bin/gzcat
+++ b/bin/gzcat
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import gzip

--- a/bin/gzsavings
+++ b/bin/gzsavings
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/hascrs
+++ b/bin/hascrs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/headgrep
+++ b/bin/headgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Do a `head` or `tail` based on a regular expression

--- a/bin/headingsort
+++ b/bin/headingsort
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import logging

--- a/bin/headtail
+++ b/bin/headtail
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import math

--- a/bin/hex
+++ b/bin/hex
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/hidedate
+++ b/bin/hidedate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/homedir
+++ b/bin/homedir
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/htmlize
+++ b/bin/htmlize
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import getopt

--- a/bin/incomingHost
+++ b/bin/incomingHost
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import re

--- a/bin/indent
+++ b/bin/indent
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/invert
+++ b/bin/invert
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 assert not sys.stdin.isatty(), "stdin must be directed"

--- a/bin/ipactivity
+++ b/bin/ipactivity
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/ipaddr
+++ b/bin/ipaddr
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import re

--- a/bin/ipstatus
+++ b/bin/ipstatus
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import time

--- a/bin/isbinary
+++ b/bin/isbinary
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/isgit
+++ b/bin/isgit
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/istext
+++ b/bin/istext
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/jeval
+++ b/bin/jeval
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import random

--- a/bin/json
+++ b/bin/json
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/json2table
+++ b/bin/json2table
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Takes a list of dictionaries in JSON form and converts it to table.

--- a/bin/jsoncompare
+++ b/bin/jsoncompare
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/jsondiff
+++ b/bin/jsondiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/jsonelem
+++ b/bin/jsonelem
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/jsonflatten
+++ b/bin/jsonflatten
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Takes a json object and dumps out all of the values (one per line)

--- a/bin/jsonhunt
+++ b/bin/jsonhunt
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/jsonjoin
+++ b/bin/jsonjoin
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import pdb
 

--- a/bin/jsons
+++ b/bin/jsons
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import json
 import sys

--- a/bin/jsonsniff
+++ b/bin/jsonsniff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import json
 import sys

--- a/bin/kubelogs
+++ b/bin/kubelogs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import json
 import logging

--- a/bin/lexec
+++ b/bin/lexec
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import os.path

--- a/bin/linelengths
+++ b/bin/linelengths
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/listall
+++ b/bin/listall
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/logsimplifier
+++ b/bin/logsimplifier
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
 Simplify log messages

--- a/bin/logtime
+++ b/bin/logtime
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/longjson
+++ b/bin/longjson
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import json

--- a/bin/longlines
+++ b/bin/longlines
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/loudgrep
+++ b/bin/loudgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import re

--- a/bin/lspath
+++ b/bin/lspath
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/makeawshosts
+++ b/bin/makeawshosts
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/makeawshosts.old
+++ b/bin/makeawshosts.old
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/makepdoc
+++ b/bin/makepdoc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import math

--- a/bin/manipulate
+++ b/bin/manipulate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Make changes to a stream.  Here's an example:

--- a/bin/math
+++ b/bin/math
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import argparse
 import sys

--- a/bin/megadiff
+++ b/bin/megadiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/megadiff.old
+++ b/bin/megadiff.old
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import subprocess

--- a/bin/megahosts
+++ b/bin/megahosts
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/megascp
+++ b/bin/megascp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/megassh
+++ b/bin/megassh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/megasum
+++ b/bin/megasum
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Perform md5sum against local and remote files (via ssh).  This works best

--- a/bin/methods
+++ b/bin/methods
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/metricsniff
+++ b/bin/metricsniff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Sniff out metrics from graphite

--- a/bin/mongocli
+++ b/bin/mongocli
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/mtime
+++ b/bin/mtime
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/nagger
+++ b/bin/nagger
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Print random strings while sleeping between each line.  This can be used

--- a/bin/nearcompare
+++ b/bin/nearcompare
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/needformat
+++ b/bin/needformat
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/needsdoc
+++ b/bin/needsdoc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/newdirs
+++ b/bin/newdirs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/nocrs
+++ b/bin/nocrs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/noctl
+++ b/bin/noctl
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/nodebug
+++ b/bin/nodebug
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Runs a command and disposes of "shell debugging messages".  These

--- a/bin/nopassword
+++ b/bin/nopassword
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Replace passwords in stdin, sending to stdout. This only works when there is on 

--- a/bin/notempty
+++ b/bin/notempty
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/now
+++ b/bin/now
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import datetime
 

--- a/bin/numsort
+++ b/bin/numsort
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/old-git
+++ b/bin/old-git
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/old-ipaddr
+++ b/bin/old-ipaddr
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import sys

--- a/bin/old-units
+++ b/bin/old-units
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import math

--- a/bin/oldjson
+++ b/bin/oldjson
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/oldjson.py
+++ b/bin/oldjson.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import getopt

--- a/bin/oldtable
+++ b/bin/oldtable
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import csv

--- a/bin/oldtable.py
+++ b/bin/oldtable.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import re

--- a/bin/panalyze
+++ b/bin/panalyze
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import json

--- a/bin/paramiko
+++ b/bin/paramiko
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/pattern
+++ b/bin/pattern
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 def dump(num, line):
   print "%6d %s" % (num, line)

--- a/bin/pcentgrep
+++ b/bin/pcentgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/peval
+++ b/bin/peval
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import logging

--- a/bin/pgroups
+++ b/bin/pgroups
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/pinger
+++ b/bin/pinger
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/pings
+++ b/bin/pings
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/pinpoint
+++ b/bin/pinpoint
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging
 import argparse

--- a/bin/plogging
+++ b/bin/plogging
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/plumb
+++ b/bin/plumb
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/popener
+++ b/bin/popener
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging
 import argparse

--- a/bin/portlook
+++ b/bin/portlook
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import socket

--- a/bin/preplace
+++ b/bin/preplace
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/prettymetrics
+++ b/bin/prettymetrics
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import json
 import sys

--- a/bin/proc
+++ b/bin/proc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/procsort
+++ b/bin/procsort
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import getopt

--- a/bin/pscope
+++ b/bin/pscope
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
 Scope out stdin

--- a/bin/pstrings
+++ b/bin/pstrings
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import string

--- a/bin/psub
+++ b/bin/psub
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import re

--- a/bin/ptime
+++ b/bin/ptime
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
 Improved time utility, to replace /usr/bin/time.

--- a/bin/pullfrommine
+++ b/bin/pullfrommine
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/pushsshkey.py
+++ b/bin/pushsshkey.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/bin/pushtomine
+++ b/bin/pushtomine
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging
 import argparse

--- a/bin/pwc
+++ b/bin/pwc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import getopt

--- a/bin/pycomment
+++ b/bin/pycomment
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    A vi command to comment-out and un-comment a section of Python code

--- a/bin/pygrep
+++ b/bin/pygrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/pyps
+++ b/bin/pyps
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Perform subprocess.Popen() for a shell command and print results

--- a/bin/pysub
+++ b/bin/pysub
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/qdiff
+++ b/bin/qdiff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Compare file trees and report just the names of files that are different

--- a/bin/random
+++ b/bin/random
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import random
 import sys

--- a/bin/rate
+++ b/bin/rate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/recentdownloads
+++ b/bin/recentdownloads
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/remove_highlighting
+++ b/bin/remove_highlighting
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Remove hightlighitng common in output on Linux.  For instance:

--- a/bin/repeat
+++ b/bin/repeat
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import time

--- a/bin/repos
+++ b/bin/repos
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/repr
+++ b/bin/repr
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/reserve
+++ b/bin/reserve
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/reverse
+++ b/bin/reverse
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/rows
+++ b/bin/rows
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Display portions of stdin through their specific line numbers (zero based), ranges of line numbers, and regular expressions

--- a/bin/safer
+++ b/bin/safer
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Purpose: This script helps me manage the `toys` repo on multiple systems and check in existing

--- a/bin/sample
+++ b/bin/sample
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/sanitize
+++ b/bin/sanitize
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import re

--- a/bin/seejson
+++ b/bin/seejson
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/seetext
+++ b/bin/seetext
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import logging

--- a/bin/seexml
+++ b/bin/seexml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import re

--- a/bin/sizer
+++ b/bin/sizer
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Calculate the amount of disk space taken up by a file or directory tree, ignoring symlinks and only counting files once if it's hard-linked more than once in a tree

--- a/bin/stayawake
+++ b/bin/stayawake
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Keep a terminal awake so that it doesn't time out

--- a/bin/strjoin
+++ b/bin/strjoin
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import string

--- a/bin/table.py
+++ b/bin/table.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/table2json
+++ b/bin/table2json
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Takes a table in text form and converts it to JSON.

--- a/bin/tabular
+++ b/bin/tabular
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Turn any text with lines that are made up of tokens separated by some

--- a/bin/tailer
+++ b/bin/tailer
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/tailer.py
+++ b/bin/tailer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # this is similar to the tail command but it reads from the very beginning of the stdin and keeps reading
 

--- a/bin/tailgrep
+++ b/bin/tailgrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
   Do a `head` or `tail` based on a regular expression

--- a/bin/tarcopy
+++ b/bin/tarcopy
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/tartoc
+++ b/bin/tartoc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/timefun
+++ b/bin/timefun
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/timemachine
+++ b/bin/timemachine
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/timemagic
+++ b/bin/timemagic
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/timer
+++ b/bin/timer
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/timescope
+++ b/bin/timescope
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/timestamp
+++ b/bin/timestamp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # date '+%Y-%m-%dT%H:%M:%S.%N'
 

--- a/bin/timestamps
+++ b/bin/timestamps
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os.path

--- a/bin/tohtml
+++ b/bin/tohtml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import logging

--- a/bin/toyaml
+++ b/bin/toyaml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import json

--- a/bin/trash
+++ b/bin/trash
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import random

--- a/bin/truepath.py
+++ b/bin/truepath.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/undupe
+++ b/bin/undupe
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Replace duplicate "non-essential" characters with a single

--- a/bin/uniqc
+++ b/bin/uniqc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import math

--- a/bin/units
+++ b/bin/units
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/unixdate
+++ b/bin/unixdate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/vctl
+++ b/bin/vctl
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import json

--- a/bin/virtual_hosts.py
+++ b/bin/virtual_hosts.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/viswap
+++ b/bin/viswap
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import logging
 import argparse

--- a/bin/vscp
+++ b/bin/vscp
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import logging

--- a/bin/vssh
+++ b/bin/vssh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/watcher
+++ b/bin/watcher
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import subprocess
 import sys

--- a/bin/wcsum
+++ b/bin/wcsum
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Reports `wc` and `md5sum` information on files together on the same line

--- a/bin/webwatch
+++ b/bin/webwatch
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import sys

--- a/bin/whatami
+++ b/bin/whatami
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/bin/whatfile
+++ b/bin/whatfile
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/whatgit
+++ b/bin/whatgit
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
    Find location of the nearest `.git` file in the file structure - this will tell us the root directory of this local git repository.

--- a/bin/wholegrep
+++ b/bin/wholegrep
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/windozescreensavers
+++ b/bin/windozescreensavers
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import os

--- a/bin/xml
+++ b/bin/xml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import re
 import sys

--- a/bin/yaml
+++ b/bin/yaml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import yaml

--- a/bin/zerojoin
+++ b/bin/zerojoin
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 

--- a/bin/zombies
+++ b/bin/zombies
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import pwd

--- a/misc/setup
+++ b/misc/setup
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import gzip
 import base64

--- a/test/table/test.py
+++ b/test/table/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re


### PR DESCRIPTION
I had a need to use python3 for some work but wanted to keep the ability to use my python2 scripts too.  I'm changing all the scripts that just have something like:

  #! /usr/bin/env python

to:

  #! /usr/bin/env python2